### PR TITLE
Added API to get expected colors for Macbeth color charts in MCC module

### DIFF
--- a/modules/mcc/include/opencv2/mcc/ccm.hpp
+++ b/modules/mcc/include/opencv2/mcc/ccm.hpp
@@ -392,6 +392,13 @@ public:
     */
     CV_WRAP ColorCorrectionModel(const Mat& src, Mat colors, COLOR_SPACE ref_cs, Mat colored);
 
+    /** @brief Set the reference color using a built-in (CONST_COLOR) reference color chart.
+     *  This lets you change the reference color patch data after you’ve constructed
+     *  the model or at any time.
+     @param output original color values
+     */
+    void getColorMatrix(CONST_COLOR constcolor, Mat& output);
+
     /** @brief set ColorSpace
     @note It should be some RGB color space;
     Supported list of color cards:

--- a/modules/mcc/src/ccm.cpp
+++ b/modules/mcc/src/ccm.cpp
@@ -101,6 +101,7 @@ public:
 
     void getColor(Mat& img_, bool islinear = false);
     void getColor(CONST_COLOR constcolor);
+    void getColorMatrix(CONST_COLOR constcolor, Mat& output);
     void getColor(Mat colors_, COLOR_SPACE cs_, Mat colored_);
     void getColor(Mat colors_, COLOR_SPACE ref_cs_);
 
@@ -302,6 +303,11 @@ void ColorCorrectionModel::Impl::getColor(CONST_COLOR constcolor)
 {
     dst = (GetColor::getColor(constcolor));
 }
+void ColorCorrectionModel::Impl::getColorMatrix(CONST_COLOR constcolor, Mat& output)
+{
+    dst = (GetColor::getColor(constcolor));
+    output = dst->colors;
+}
 void ColorCorrectionModel::Impl::getColor(Mat colors_, COLOR_SPACE ref_cs_)
 {
     dst.reset(new Color(colors_, *GetCS::getInstance().get_cs(ref_cs_)));
@@ -309,6 +315,10 @@ void ColorCorrectionModel::Impl::getColor(Mat colors_, COLOR_SPACE ref_cs_)
 void ColorCorrectionModel::Impl::getColor(Mat colors_, COLOR_SPACE cs_, Mat colored_)
 {
     dst.reset(new Color(colors_, *GetCS::getInstance().get_cs(cs_), colored_));
+}
+void ColorCorrectionModel::getColorMatrix(CONST_COLOR constcolor, Mat& output)
+{
+    p->getColorMatrix(constcolor, output);
 }
 ColorCorrectionModel::ColorCorrectionModel(const Mat& src_, CONST_COLOR constcolor)
     : p(std::make_shared<Impl>())


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
